### PR TITLE
fixed error logic and target error

### DIFF
--- a/assets/asset.json
+++ b/assets/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "hdfs",
-    "version": "0.1.36",
+    "version": "0.1.40",
     "description": "A set of assets for interacting with HDFS data"
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hdfs",
-  "version": "0.1.36",
+  "version": "0.1.40",
   "description": "A bundle of assets for interacting with HDFS ",
   "main": "index.js",
   "repository": "https://github.com/terascope/hdfs-assets.git",


### PR DESCRIPTION
Changed the error logic to look for `remoteexception.js`, which as far as I can tell, is the only evidence that the HDFS append is happening due to the block relocation bug.

The appearance of `AlreadyBeingCreatedException` in the HDFS append error message is the result of a different problem that appears to be caused during a similar block relocation scenario. The exact cause and steps needed to fix this need to be investigated further.