### PR TITLE
fixed logic to account for changing filenames

### DIFF
--- a/assets/asset.json
+++ b/assets/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "hdfs",
-    "version": "0.1.40",
+    "version": "0.1.42",
     "description": "A set of assets for interacting with HDFS data"
 }

--- a/assets/hdfs_append/index.js
+++ b/assets/hdfs_append/index.js
@@ -27,12 +27,7 @@ function _recordFileError(name, errorLog) {
     // Get the original file name from the error message. If there have been no previous errors
     // for the given file, this will result in a bogus filename that will trigger the second
     // block of the following checks. Otherwise, the third block will be used to get a new name
-    const fileBase = name
-        .split('.')
-        .reverse()
-        .splice(1)
-        .reverse()
-        .join('.');
+    const fileBase = name.substring(0, name.lastIndexOf('.'));
     if (!errorLog.retry) {
         // In this case, there has not been any hdfs append errors for a worker
 
@@ -57,7 +52,7 @@ function _recordFileError(name, errorLog) {
         // In this case, there has been at least one hdfs append error for the given file
 
         // Get the last attempted file and increment the number
-        const incNum = errorLog[fileBase].split('.').reverse()[0] * 1 + 1;
+        const incNum = +errorLog[fileBase].split('.').slice(-1) + 1;
         newFilename = `${fileBase}.${incNum}`;
         // Set the new target for the next slice attempt
         errorLog[fileBase] = newFilename;
@@ -71,7 +66,7 @@ function _checkFileHistory(name, errorLog, maxWrites) {
     // If the file has already had an error, update the filename for the next write
     // attempt
     if (errorLog[name]) {
-        const attemptNum = errorLog[name].split('.').reverse()[0] * 1;
+        const attemptNum = +errorLog[name].split('.').slice(-1);
         // This stops the worker from creating too many new files
         if (attemptNum > maxWrites) {
             throw new Error(

--- a/assets/hdfs_append/index.js
+++ b/assets/hdfs_append/index.js
@@ -21,6 +21,68 @@ function getClient(context, config, type) {
     return context.foundation.getConnection(clientConfig);
 }
 
+// Records the name of the offending file with a detected corrupt block in `appendErrors`
+function _recordFileError(name, errorLog) {
+    let newFilename = '';
+    // Get the original file name from the error message. If there have been no previous errors
+    // for the given file, this will result in a bogus filename that will trigger the second
+    // block of the following checks. Otherwise, the third block will be used to get a new name
+    const fileBase = name
+        .split('.')
+        .reverse()
+        .splice(1)
+        .reverse()
+        .join('.');
+    if (!errorLog.retry) {
+        // In this case, there has not been any hdfs append errors for a worker
+
+        newFilename = `${name}.0`;
+        errorLog[name] = newFilename;
+        // Ensures this block will not be executed again after the first error for a file
+        errorLog.retry = true;
+    } else if (!errorLog[fileBase]) {
+        // In this case, there has been at least one hdfs append error for a worker, but the
+        // worker is now writing to a new file
+
+        // Clean out the appendErrors object to avoid an accumulation of filenames
+        Object.keys(errorLog).forEach((key) => {
+            delete errorLog[key];
+        });
+
+        newFilename = `${name}.0`;
+        errorLog[name] = newFilename;
+        // Add the `retry` key back in
+        errorLog.retry = true;
+    } else {
+        // In this case, there has been at least one hdfs append error for the given file
+
+        // Get the last attempted file and increment the number
+        const incNum = errorLog[fileBase].split('.').reverse()[0] * 1 + 1;
+        newFilename = `${fileBase}.${incNum}`;
+        // Set the new target for the next slice attempt
+        errorLog[fileBase] = newFilename;
+    }
+    return newFilename;
+}
+
+// This just checks `appendErrors` for the file to determine if data needs to be redirected to
+// the new file
+function _checkFileHistory(name, errorLog, maxWrites) {
+    // If the file has already had an error, update the filename for the next write
+    // attempt
+    if (errorLog[name]) {
+        const attemptNum = errorLog[name].split('.').reverse()[0] * 1;
+        // This stops the worker from creating too many new files
+        if (attemptNum > maxWrites) {
+            throw new Error(
+                `${name} has exceeded the maximum number of write attempts!`
+            );
+        }
+        return errorLog[name];
+    }
+    return name;
+}
+
 function newProcessor(context, opConfig) {
     const logger = context.apis.foundation.makeLogger({ module: 'hdfs_append' });
     // Client connection cannot be cached, an endpoint needs to be re-instantiated for a different
@@ -39,48 +101,6 @@ function newProcessor(context, opConfig) {
     //       processing duration will keep the worker from toppling the Namenode
     const appendErrors = {};
 
-    // Records the name of the offending file with a detected corrupt block in `appendErrors`
-    function recordFileError(name) {
-        let newFilename = '';
-        if (!appendErrors.retry && !appendErrors[name]) {
-            newFilename = `${name}.0`;
-            appendErrors[name] = newFilename;
-            // Ensures this block will not be executed again after the first error for a file
-            appendErrors.retry = true;
-        } else {
-            // Get the original file name from the error message
-            const originalFile = name
-                .split('.')
-                .reverse()
-                .splice(1)
-                .reverse()
-                .join('.');
-            // Get the last attempted file and increment the number
-            const incNum = appendErrors[originalFile].split('.').reverse()[0] * 1 + 1;
-            newFilename = `${originalFile}.${incNum}`;
-            // Set the new target for the next slice attempt
-            appendErrors[originalFile] = newFilename;
-        }
-        return newFilename;
-    }
-
-    // This just checks `appendErrors` for the file to determine if data needs to be redirected to
-    // the new file
-    function checkFileHistory(name) {
-        // If the file has already had an error, update the filename for the next write
-        // attempt
-        if (appendErrors[name]) {
-            const attemptNum = appendErrors[name].split('.').reverse()[0] * 1;
-            // This stops the worker from creating too many new files
-            if (attemptNum > opConfig.max_write_errors) {
-                throw new Error(
-                    `${name} has exceeded the maximum number of write attempts!`
-                );
-            }
-            return appendErrors[name];
-        }
-        return name;
-    }
 
     const clientService = getClient(context, opConfig, 'hdfs_ha');
     const hdfsClient = clientService.client;
@@ -110,7 +130,7 @@ function newProcessor(context, opConfig) {
                 /* this check.
                  */
                 if (errMsg.indexOf('remoteexception.js') > -1) {
-                    const newFilename = recordFileError(filename);
+                    const newFilename = _recordFileError(filename, appendErrors);
                     sliceError = `Error sending data to file '${filename}' due to HDFS append `
                         + `error. Changing destination to '${newFilename}'. Error: ${errMsg}`;
                 } else {
@@ -129,7 +149,11 @@ function newProcessor(context, opConfig) {
         data.forEach((record) => {
             // This skips any records that have non-existant data payloads to avoid empty appends
             if (record.data.length > 0) {
-                const file = checkFileHistory(record.filename);
+                const file = _checkFileHistory(
+                    record.filename,
+                    appendErrors,
+                    opConfig.max_write_errors
+                );
                 if (!map[file]) map[file] = [];
                 map[file].push(record.data);
             }
@@ -184,5 +208,7 @@ function schema() {
 
 module.exports = {
     newProcessor,
+    _recordFileError,
+    _checkFileHistory,
     schema
 };

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hdfs",
-  "version": "0.1.40",
+  "version": "0.1.42",
   "description": "A bundle of assets for interacting with HDFS ",
   "main": "index.js",
   "repository": "https://github.com/terascope/hdfs-assets.git",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,31 @@
   "repository": "https://github.com/terascope/hdfs-assets.git",
   "author": "Zach Burnham <zburnham@terascope.io>",
   "license": "MIT",
-  "dependencies": {
-    "@terascope/queue": "^1.1.3",
-    "@terascope/teraslice-op-test-harness": "^1.0.0",
-    "bluebird": "^3.5.1",
+  "scripts": {
+    "lint": "eslint *.js spec lib",
+    "lint:fix": "eslint --fix *.js spec lib",
+    "test": "nyc -x spec/ --reporter=text-summary jasmine && nyc report --reporter=html",
+    "report-coverage": "nyc report --reporter=text-lcov > coverage/coverage.lcov && codecov"
+  },
+  "nyc": {
+    "cache": true,
+    "all": true,
+    "include": [
+      "*.js",
+      "lib/*.js"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "lcov",
+      "json"
+    ]
+  },
+  "devDependencies": {
     "eslint": "^5.3.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
-    "lodash": "^4.17.10",
-    "nock": "^9.6.1"
+    "jasmine": "^3.2.0",
+    "jasmine-spec-reporter": "^4.2.1"
   }
 }

--- a/spec/hdfs-append-spec.js
+++ b/spec/hdfs-append-spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const hdfsAppend = require('../assets/hdfs_append/index.js');
+
+
+// Start out with no file errors
+const appendErrors = {};
+
+describe('The hdfs_append processor', () => {
+    it('properly passes a clean filename through.', () => {
+        const filename = '/incoming-data/2037-2-27/ts-worker.lan.42';
+        const newName = hdfsAppend._checkFileHistory(filename, appendErrors, 100);
+        expect(newName).toEqual(filename);
+        expect(Object.keys(appendErrors).length).toEqual(0);
+    });
+    it('properly changes the filename after an HDFS append error.', () => {
+        const filename = '/incoming-data/2037-2-27/ts-worker.lan.42';
+        const newName = hdfsAppend._recordFileError(filename, appendErrors);
+        expect(newName).toEqual('/incoming-data/2037-2-27/ts-worker.lan.42.0');
+        expect(Object.keys(appendErrors).length).toEqual(2);
+        expect(appendErrors.retry).toEqual(true);
+        expect(appendErrors['/incoming-data/2037-2-27/ts-worker.lan.42'])
+            .toEqual('/incoming-data/2037-2-27/ts-worker.lan.42.0');
+    });
+    it('properly changes the filename after a second HDFS append error.', () => {
+        const filename = '/incoming-data/2037-2-27/ts-worker.lan.42.0';
+        const newName = hdfsAppend._recordFileError(filename, appendErrors);
+        expect(newName).toEqual('/incoming-data/2037-2-27/ts-worker.lan.42.1');
+        expect(Object.keys(appendErrors).length).toEqual(2);
+        expect(appendErrors.retry).toEqual(true);
+        expect(appendErrors['/incoming-data/2037-2-27/ts-worker.lan.42'])
+            .toEqual('/incoming-data/2037-2-27/ts-worker.lan.42.1');
+    });
+    it('properly passes a clean filename for the next day.', () => {
+        const filename = '/incoming-data/2037-2-28/ts-worker.lan.42';
+        const newName = hdfsAppend._checkFileHistory(filename, appendErrors, 100);
+        expect(newName).toEqual(filename);
+        expect(appendErrors.retry).toEqual(true);
+        expect(appendErrors['/incoming-data/2037-2-27/ts-worker.lan.42'])
+            .toEqual('/incoming-data/2037-2-27/ts-worker.lan.42.1');
+    });
+    it('properly changes the filename after an HDFS append error for the new file.', () => {
+        const filename = '/incoming-data/2037-2-28/ts-worker.lan.42';
+        const newName = hdfsAppend._recordFileError(filename, appendErrors);
+        expect(newName).toEqual('/incoming-data/2037-2-28/ts-worker.lan.42.0');
+        expect(appendErrors.retry).toEqual(true);
+        expect(appendErrors['/incoming-data/2037-2-28/ts-worker.lan.42'])
+            .toEqual('/incoming-data/2037-2-28/ts-worker.lan.42.0');
+    });
+});

--- a/spec/helpers/reporter.js
+++ b/spec/helpers/reporter.js
@@ -1,0 +1,12 @@
+'use strict';
+
+if (process.stdout.isTTY) {
+    const { SpecReporter } = require('jasmine-spec-reporter');
+    jasmine.getEnv().clearReporters();
+    jasmine.getEnv().addReporter(new SpecReporter({
+        spec: {
+            displayStacktrace: true,
+            displayDuration: true
+        }
+    }));
+}

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,75 +2,6 @@
 # yarn lockfile v1
 
 
-"@terascope/job-components@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.2.0.tgz#45bd2e10fc7b6153bbe9420d5c715a9c905d4598"
-  dependencies:
-    "@terascope/teraslice-types" "^0.1.0"
-    "@types/fs-extra" "^5.0.4"
-    "@types/lodash" "^4.14.116"
-    "@types/node" "^10.7.1"
-    fs-extra "^7.0.0"
-    rimraf "^2.0.0"
-    ts-node "^7.0.1"
-    typescript "^3.0.1"
-
-"@terascope/queue@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@terascope/queue/-/queue-1.1.3.tgz#a58419716d43d12ad09491cabb6fab306cc64931"
-
-"@terascope/teraslice-op-test-harness@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@terascope/teraslice-op-test-harness/-/teraslice-op-test-harness-1.1.0.tgz#5c76040b33f08745dec8f9975c69e51135cac460"
-  dependencies:
-    "@terascope/job-components" "^0.2.0"
-    "@terascope/teraslice-types" "^0.1.0"
-    bluebird "^3.5.1"
-    lodash "^4.17.4"
-
-"@terascope/teraslice-types@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@terascope/teraslice-types/-/teraslice-types-0.1.0.tgz#5fcb3b1412d1dd2ada821a539b0f9e3498ecf7d3"
-  dependencies:
-    "@types/bunyan" "^1.8.4"
-    "@types/convict" "^4.2.0"
-    "@types/lodash" "^4.14.116"
-    "@types/node" "^10.7.1"
-    bunyan "^1.8.12"
-    convict "^4.3.2"
-    debugnyan "^2.0.2"
-    rimraf "^2.0.0"
-    typescript "^3.0.1"
-
-"@types/bunyan@^1.8.4":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.4.tgz#69c11adc7b50538d45fb68d9ae39d062b9432f38"
-  dependencies:
-    "@types/events" "*"
-    "@types/node" "*"
-
-"@types/convict@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@types/convict/-/convict-4.2.0.tgz#87ec9c10bfae801f79bf9dfa0f603c064e2fa5fa"
-
-"@types/events@*":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
-
-"@types/fs-extra@^5.0.4":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.4.tgz#b971134d162cc0497d221adde3dbb67502225599"
-  dependencies:
-    "@types/node" "*"
-
-"@types/lodash@^4.14.116":
-  version "4.14.116"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
-
-"@types/node@*", "@types/node@^10.7.1":
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
-
 acorn-jsx@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
@@ -136,10 +67,6 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-assertion-error@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
-
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -152,10 +79,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-bluebird@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -163,22 +86,9 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-buffer-from@^1.0.0, buffer-from@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-
-bunyan@^1.8.1, bunyan@^1.8.12:
-  version "1.8.12"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
-  optionalDependencies:
-    dtrace-provider "~0.8"
-    moment "^2.10.6"
-    mv "~2"
-    safe-json-stringify "~1"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -189,21 +99,6 @@ caller-path@^0.1.0:
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
-
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-
-chai@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
-  dependencies:
-    assertion-error "^1.0.1"
-    check-error "^1.0.1"
-    deep-eql "^3.0.0"
-    get-func-name "^2.0.0"
-    pathval "^1.0.0"
-    type-detect "^4.0.0"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -226,10 +121,6 @@ chalk@^2.0.0, chalk@^2.1.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
-
-check-error@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -255,6 +146,10 @@ color-name@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
+colors@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -262,17 +157,6 @@ concat-map@0.0.1:
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
-
-convict@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/convict/-/convict-4.3.2.tgz#0b3ff1e96114983a7266d599d2e028bb4cdc5692"
-  dependencies:
-    depd "1.1.2"
-    json5 "1.0.1"
-    lodash.clonedeep "4.5.0"
-    moment "2.22.2"
-    validator "10.4.0"
-    yargs-parser "10.1.0"
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -284,7 +168,7 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
+debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -295,23 +179,6 @@ debug@^3.1.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
-
-debugnyan@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/debugnyan/-/debugnyan-2.0.2.tgz#83138804167ab2733988b9b0b90f0d11c9d1e1a1"
-  dependencies:
-    bunyan "^1.8.1"
-    debug "^2.2.0"
-
-deep-eql@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  dependencies:
-    type-detect "^4.0.0"
-
-deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -335,14 +202,6 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-depd@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-
-diff@^3.1.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -355,12 +214,6 @@ doctrine@^2.1.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
-
-dtrace-provider@~0.8:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
-  dependencies:
-    nan "^2.10.0"
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -575,14 +428,6 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-fs-extra@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -595,23 +440,20 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.6:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -635,7 +477,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -770,6 +612,23 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
+jasmine-core@~3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.2.1.tgz#8e4ff5b861603ee83343f2b49eee6a0ffe9650ce"
+
+jasmine-spec-reporter@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz#1d632aec0341670ad324f92ba84b4b32b35e9e22"
+  dependencies:
+    colors "1.1.2"
+
+jasmine@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.2.0.tgz#b3a018454781805650e46578803d08e7cfdd7b3d"
+  dependencies:
+    glob "^7.0.6"
+    jasmine-core "~3.2.0"
+
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -788,22 +647,6 @@ json-schema-traverse@^0.4.1:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-
-json-stringify-safe@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
-json5@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  dependencies:
-    minimist "^1.2.0"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -828,23 +671,15 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.clonedeep@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-
-make-error@^1.1.1:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-"minimatch@2 || 3", minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -854,19 +689,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-moment@2.22.2, moment@^2.10.6:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 ms@2.0.0:
   version "2.0.0"
@@ -876,43 +703,13 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-mv@~2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
-  dependencies:
-    mkdirp "~0.5.1"
-    ncp "~2.0.0"
-    rimraf "~2.4.0"
-
-nan@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-ncp@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
-
-nock@^9.6.1:
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-9.6.1.tgz#d96e099be9bc1d0189a77f4490bbbb265c381b49"
-  dependencies:
-    chai "^4.1.2"
-    debug "^3.1.0"
-    deep-equal "^1.0.0"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.5"
-    mkdirp "^0.5.0"
-    propagate "^1.0.0"
-    qs "^6.5.1"
-    semver "^5.5.0"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -1030,10 +827,6 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
-pathval@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -1066,17 +859,9 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-propagate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-
-qs@^6.5.1:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -1121,17 +906,11 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@^2.0.0, rimraf@^2.2.8:
+rimraf@^2.2.8:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
-
-rimraf@~2.4.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
-  dependencies:
-    glob "^6.0.1"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -1144,10 +923,6 @@ rxjs@^5.5.2:
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
   dependencies:
     symbol-observable "1.0.1"
-
-safe-json-stringify@~1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
@@ -1176,17 +951,6 @@ slice-ansi@1.0.0:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-
-source-map-support@^0.5.6:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@^3.0.0:
   version "3.0.0"
@@ -1280,36 +1044,11 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-ts-node@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
-  dependencies:
-    arrify "^1.0.0"
-    buffer-from "^1.1.0"
-    diff "^3.1.0"
-    make-error "^1.1.1"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map-support "^0.5.6"
-    yn "^2.0.0"
-
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
-
-type-detect@^4.0.0:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
-
-typescript@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
-
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -1323,10 +1062,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-validator@10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-10.4.0.tgz#ee99a44afb3bb5ed350a159f056ca72a204cfc3c"
 
 which@^1.2.9:
   version "1.3.1"
@@ -1347,13 +1082,3 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-yargs-parser@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  dependencies:
-    camelcase "^4.1.0"
-
-yn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"


### PR DESCRIPTION
I extracted the logic for handling the filenames and wrote tests to verify that they will properly change the filename for the first append error a worker runs into as well as any subsequent append error whether or not the name of the file has changed.

However, this has not been fully verified with a test TS job yet due to the complexity of causing the HDFS append error.