### PR TITLE
Adding matrix for builds and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - "8"
+  - "10"
+os:
+  - linux
+  - osx
 jobs:
   include:
     - script: yarn test


### PR DESCRIPTION
This built, but for reasons I don't understand the matrix, which should have had 4 things, had 5.  It looks like it repeated the linux node 8 test.